### PR TITLE
Prevent using trades with 2 items to buy in the trade exchanger (#77)

### DIFF
--- a/src/main/java/com/buuz135/industrial/tile/mob/VillagerTradeExchangerTile.java
+++ b/src/main/java/com/buuz135/industrial/tile/mob/VillagerTradeExchangerTile.java
@@ -61,6 +61,7 @@ public class VillagerTradeExchangerTile extends CustomElectricMachine {
         super.protectedUpdate();
         if (!villager.getStackInSlot(0).isEmpty() && villager.getStackInSlot(0).getTagCompound().hasKey("Offers")) {
             merchantRecipes = new MerchantRecipeList(villager.getStackInSlot(0).getTagCompound().getCompoundTag("Offers"));
+            merchantRecipes.removeIf(MerchantRecipe::hasSecondItemToBuy); // TODO this is a temporary fix until we add actual support for trades with 2 items (#77)
         } else {
             merchantRecipes = null;
             current = 0;


### PR DESCRIPTION
We currently only check the first item to buy, so allowing these kinds of
trades means that players are only having to pay one of the two items.
Long-term, we plan to add a second buying slot to the exchanger, but until
then, prevent this sort of trade.