### PR TITLE
Animal Rancher works with Fluid Cows. Fixes Issue #441

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,10 @@ repositories {
         name 'jared maven'
         url "http://maven.blamejared.com/"
     }
+    maven {
+        name = "CurseForge"
+        url = "https://minecraft.curseforge.com/api/maven/"
+    }
 }
 
 dependencies {
@@ -91,6 +95,7 @@ dependencies {
     compile "cofh:RedstoneFlux:1.12-${project.redstoneflux_version}:universal"
     compileOnly "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.10.306"
     compile files("libs/Baubles-1.12-1.5.2.jar")
+    deobfCompile "moo-fluids:MooFluids:1.12.2:1.7.11.02a"
 }
 
 processResources {

--- a/src/main/java/com/buuz135/industrial/tile/agriculture/AnimalResourceHarvesterTile.java
+++ b/src/main/java/com/buuz135/industrial/tile/agriculture/AnimalResourceHarvesterTile.java
@@ -28,6 +28,8 @@ import com.buuz135.industrial.tile.WorkingAreaElectricMachine;
 import com.buuz135.industrial.tile.api.IAcceptsFortuneAddon;
 import com.buuz135.industrial.utils.ItemStackUtils;
 import com.buuz135.industrial.utils.WorkUtils;
+import com.robrit.moofluids.common.entity.EntityFluidCow;
+
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.passive.EntitySquid;
 import net.minecraft.init.Items;
@@ -39,6 +41,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 import net.ndrei.teslacorelib.inventory.FluidTankType;
@@ -92,7 +95,12 @@ public class AnimalResourceHarvesterTile extends WorkingAreaElectricMachine impl
                 }
                 hasWorked = true;
             }
-            if (tank.getFluidAmount() <= 7000) {
+            //Check if the animal is a Fluid Cow from moofluids. If the cow has a different
+            //fluid than what is in the tank, skip it
+            if (tank.getFluidAmount() <= 7000 && 
+            		!(Loader.isModLoaded("moofluids") && tank.getFluidAmount() > 0 && 
+            		living instanceof EntityFluidCow &&
+            			((EntityFluidCow)living).getEntityFluid() != tank.getFluid().getFluid())) {
                 FakePlayer player = IndustrialForegoing.getFakePlayer(this.world);
                 player.setPosition(living.posX, living.posY, living.posZ);
                 player.setHeldItem(EnumHand.MAIN_HAND, new ItemStack(Items.BUCKET));


### PR DESCRIPTION
Before this fix, a Fake Player would milk a Moo Fluid cow with a bucket, resetting the cooldown. But, if there was a different fluid already in the Rancher's tank, the bucket would get trashed. This means all Fluid Cows in the affected area would get their cooldowns reset, but only the first cow would produce fluid. This change corrects that. 

Animal Rancher now checks if the animal is a Fluid Cow from moofluids. If the cow has a different fluid than what is in the tank, it skips it. This allows a pen full of Fluid Cows to be "milked" in rapid succession. Fixes issue #441 . Also confirmed the rancher still behaves as-expected with normal cows if MooFluids is not installed.

https://imgur.com/T1G82M8