### PR TITLE
MobImprisonmentTool: Handle special entity interactions and add owner-only capture config

### DIFF
--- a/src/main/java/com/buuz135/industrial/config/ItemCoreConfig.java
+++ b/src/main/java/com/buuz135/industrial/config/ItemCoreConfig.java
@@ -1,0 +1,8 @@
+package com.buuz135.industrial.config;
+
+import com.hrznstudio.titanium.annotation.config.ConfigFile;
+import net.neoforged.fml.config.ModConfig;
+
+@ConfigFile(value = "item-core", type = ModConfig.Type.COMMON)
+public class ItemCoreConfig {
+}

--- a/src/main/java/com/buuz135/industrial/config/item/core/MobImprisonmentToolConfig.java
+++ b/src/main/java/com/buuz135/industrial/config/item/core/MobImprisonmentToolConfig.java
@@ -1,0 +1,12 @@
+package com.buuz135.industrial.config.item.core;
+
+import com.buuz135.industrial.config.ItemCoreConfig;
+import com.hrznstudio.titanium.annotation.config.ConfigFile;
+import com.hrznstudio.titanium.annotation.config.ConfigVal;
+
+@ConfigFile.Child(ItemCoreConfig.class)
+public class MobImprisonmentToolConfig {
+
+    @ConfigVal(comment = "If true, only the player who tamed the animal can capture it.")
+    public static boolean onlyOwnerCanCapture = false;
+}

--- a/src/main/java/com/buuz135/industrial/entity/InfinityLauncherProjectileEntity.java
+++ b/src/main/java/com/buuz135/industrial/entity/InfinityLauncherProjectileEntity.java
@@ -210,7 +210,7 @@ public class InfinityLauncherProjectileEntity extends AbstractArrow {
             for (ItemStack itemStack : ((Player) player).getInventory().items) {
                 if (itemStack.getItem() instanceof MobImprisonmentToolItem && !itemStack.has(IFAttachments.MOB_IMPRISONMENT_TOOL)) {
                     ItemStack copy = itemStack.copy();
-                    if (((MobImprisonmentToolItem) itemStack.getItem()).capture(copy, (LivingEntity) entity)) {
+                    if (((MobImprisonmentToolItem) itemStack.getItem()).capture(copy, (LivingEntity) entity,((Player) player))) {
                         ((Player) player).getInventory().removeItem(itemStack);
                         ((Player) player).getInventory().add(copy);
                         break;

--- a/src/main/java/com/buuz135/industrial/item/MobImprisonmentToolItem.java
+++ b/src/main/java/com/buuz135/industrial/item/MobImprisonmentToolItem.java
@@ -21,6 +21,7 @@
  */
 package com.buuz135.industrial.item;
 
+import com.buuz135.industrial.config.item.core.MobImprisonmentToolConfig;
 import com.buuz135.industrial.utils.IFAttachments;
 import com.buuz135.industrial.utils.IndustrialTags;
 import com.hrznstudio.titanium.recipe.generator.TitaniumShapedRecipeBuilder;
@@ -38,6 +39,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.TamableAnimal;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -67,16 +70,17 @@ public class MobImprisonmentToolItem extends IFCustomItem {
 
     @Override
     public InteractionResult interactLivingEntity(ItemStack stack, Player playerIn, LivingEntity target, InteractionHand hand) {
-        if (!capture(stack, target)) return InteractionResult.FAIL;
+        if (!capture(stack, target,playerIn)) return InteractionResult.FAIL;
         playerIn.swing(hand);
         playerIn.setItemInHand(hand, stack);
         return InteractionResult.SUCCESS;
     }
 
-    public boolean capture(ItemStack stack, LivingEntity target) {
+    public boolean capture(ItemStack stack, LivingEntity target,Player player) {
         if (target.getCommandSenderWorld().isClientSide) return false;
         if (target instanceof Player || target.getType().is(Tags.EntityTypes.BOSSES) || !target.isAlive()) return false;
         if (containsEntity(stack)) return false;
+        if (!canPlayerCaptureEntity(target,player)) return false;
         if (isBlacklisted(target.getType())) return false;
         CompoundTag nbt = new CompoundTag();
         nbt.putString("entity", EntityType.getKey(target.getType()).toString());
@@ -97,6 +101,41 @@ public class MobImprisonmentToolItem extends IFCustomItem {
         return true;
     }
 
+    /**
+     * Determines whether the given player is allowed to capture the specified entity.
+     * The decision depends on the entity type and the current configuration:
+     *  Tamable animals: If owner-only capture is enabled, only the player
+     *       who tamed the animal may capture it. Untamed animals can always be captured.
+     *  Horses and horse-like entities: If owner-only capture is enabled,
+     *       only the owning player may capture a tamed horse. Untamed horses can always
+     *       be captured.
+     *   Other entities: Always capturable by default.
+     * </ul>
+     *
+     * @param entity the target living entity the player is attempting to capture
+     * @param player the player attempting to capture the entity
+     * @return {@code true} if the player is allowed to capture the entity,
+     *         {@code false} otherwise
+     */
+    private boolean canPlayerCaptureEntity(LivingEntity entity, Player player){
+        var ret = false;
+        switch (entity) {
+            case AbstractHorse horse -> {
+                if (!MobImprisonmentToolConfig.onlyOwnerCanCapture || ((horse.isTamed()
+                        && horse.getOwnerUUID() != null
+                        && horse.getOwnerUUID().equals(player.getUUID())) || !horse.isTamed())) {
+                    ret = true;
+                }
+            }
+            case TamableAnimal animal -> {
+                if (!MobImprisonmentToolConfig.onlyOwnerCanCapture || (animal.isTame() && animal.isOwnedBy(player)) || !animal.isTame()) {
+                        ret = true;
+                }
+            }
+            default -> ret = true;
+        }
+        return ret;
+    }
     public boolean isBlacklisted(EntityType<?> entity) {
         return TagUtil.hasTag(BuiltInRegistries.ENTITY_TYPE, entity, IndustrialTags.EntityTypes.MOB_IMPRISONMENT_TOOL_BLACKLIST);
     }

--- a/src/main/java/com/buuz135/industrial/proxy/CommonProxy.java
+++ b/src/main/java/com/buuz135/industrial/proxy/CommonProxy.java
@@ -23,6 +23,7 @@
 package com.buuz135.industrial.proxy;
 
 import com.buuz135.industrial.proxy.event.FakePlayerRideEntityHandler;
+import com.buuz135.industrial.proxy.event.MobImprisonmentTamableEntitiesHandler;
 import com.buuz135.industrial.utils.explosion.ExplosionTickHandler;
 import com.hrznstudio.titanium.event.handler.EventManager;
 import net.neoforged.neoforge.common.NeoForge;
@@ -32,7 +33,7 @@ public class CommonProxy {
 
     public void run() {
         NeoForge.EVENT_BUS.register(new FakePlayerRideEntityHandler());
-
+        NeoForge.EVENT_BUS.register(new MobImprisonmentTamableEntitiesHandler());
         EventManager.forge(ServerTickEvent.Pre.class).process(ExplosionTickHandler::serverTick).subscribe();
     }
 

--- a/src/main/java/com/buuz135/industrial/proxy/event/MobImprisonmentTamableEntitiesHandler.java
+++ b/src/main/java/com/buuz135/industrial/proxy/event/MobImprisonmentTamableEntitiesHandler.java
@@ -1,0 +1,39 @@
+package com.buuz135.industrial.proxy.event;
+
+import com.buuz135.industrial.item.MobImprisonmentToolItem;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.TamableAnimal;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.npc.Villager;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+
+public class MobImprisonmentTamableEntitiesHandler {
+    /**
+     * This event is used to intercept entities that normally perform special vanilla
+     * interactions on right-click (such as villagers opening a trade GUI, animals sitting,
+     * or horses being mounted). When the MobImprisonmentTool is used, the vanilla interaction is cancelled
+     * and replaced by the capture logic.
+     *
+     * @param event
+     */
+    @SubscribeEvent
+    public void onPlayerInteractEntityInteract(PlayerInteractEvent.EntityInteract event) {
+        if (event.getLevel().isClientSide) return;
+
+        if ((!event.getItemStack().isEmpty() && event.getItemStack().getItem() instanceof MobImprisonmentToolItem item)) {
+            var player = event.getEntity();
+            var livingEntity = event.getTarget();
+
+            if (livingEntity instanceof Villager
+                    || livingEntity instanceof TamableAnimal
+                    || livingEntity instanceof AbstractHorse) {
+                item.capture(event.getItemStack(), (LivingEntity) livingEntity, player);
+
+                event.setCanceled(true);
+                event.setCancellationResult(InteractionResult.SUCCESS);
+            }
+        }
+    }
+}


### PR DESCRIPTION
MobImprisonmentTool: 
- Improves capture handling for tamable animals, horses, and other entities with special right-click behavior -> should fix #1625 
- Adds an optional owner-only capture restriction for tamable animals via config. 