### PR TITLE
perf: early exit before checking environment redstone if redstone action is ignored

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/misc/tile/InfinityChargerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/misc/tile/InfinityChargerTile.java
@@ -25,6 +25,7 @@ import com.buuz135.industrial.block.tile.IndustrialMachineTile;
 import com.buuz135.industrial.item.infinity.InfinityEnergyStorage;
 import com.buuz135.industrial.module.ModuleMisc;
 import com.hrznstudio.titanium.annotation.Save;
+import com.hrznstudio.titanium.block.redstone.RedstoneAction;
 import com.hrznstudio.titanium.component.energy.EnergyStorageComponent;
 import com.hrznstudio.titanium.component.inventory.SidedInventoryComponent;
 import net.minecraft.core.BlockPos;
@@ -49,22 +50,23 @@ public class InfinityChargerTile extends IndustrialMachineTile<InfinityChargerTi
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state, InfinityChargerTile blockEntity) {
-        if (!chargingSlot.getStackInSlot(0).isEmpty() && this.getRedstoneManager().getAction().canRun(this.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()) {
-            var iEnergyStorage = chargingSlot.getStackInSlot(0).getCapability(Capabilities.EnergyStorage.ITEM);
-            if (iEnergyStorage != null && this.getEnergyStorage() instanceof InfinityEnergyStorage) {
-                if (iEnergyStorage instanceof InfinityEnergyStorage) {
-                    long added = Math.min(Long.MAX_VALUE - ((InfinityEnergyStorage) iEnergyStorage).getLongEnergyStored(), Math.min(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongCapacity(), ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored()));
-                    ((InfinityEnergyStorage) iEnergyStorage).setEnergyStored(((InfinityEnergyStorage) iEnergyStorage).getLongEnergyStored() + added);
-                    ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).setEnergyStored(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored() - added);
-                    markForUpdate();
-                } else {
-                    int extracted = this.getEnergyStorage().getEnergyStored();
-                    ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).setEnergyStored(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored() - iEnergyStorage.receiveEnergy(extracted, false));
-                    markForUpdate();
+        if (!chargingSlot.getStackInSlot(0).isEmpty())
+            if (this.getRedstoneManager().getAction() == RedstoneAction.IGNORE || (this.getRedstoneManager().getAction().canRun(this.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork())) {
+                var iEnergyStorage = chargingSlot.getStackInSlot(0).getCapability(Capabilities.EnergyStorage.ITEM);
+                if (iEnergyStorage != null && this.getEnergyStorage() instanceof InfinityEnergyStorage) {
+                    if (iEnergyStorage instanceof InfinityEnergyStorage) {
+                        long added = Math.min(Long.MAX_VALUE - ((InfinityEnergyStorage) iEnergyStorage).getLongEnergyStored(), Math.min(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongCapacity(), ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored()));
+                        ((InfinityEnergyStorage) iEnergyStorage).setEnergyStored(((InfinityEnergyStorage) iEnergyStorage).getLongEnergyStored() + added);
+                        ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).setEnergyStored(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored() - added);
+                        markForUpdate();
+                    } else {
+                        int extracted = this.getEnergyStorage().getEnergyStored();
+                        ((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).setEnergyStored(((InfinityEnergyStorage<InfinityChargerTile>) this.getEnergyStorage()).getLongEnergyStored() - iEnergyStorage.receiveEnergy(extracted, false));
+                        markForUpdate();
+                    }
                 }
+                this.getRedstoneManager().finish();
             }
-            this.getRedstoneManager().finish();
-        }
     }
 
     @Override

--- a/src/main/java/com/buuz135/industrial/block/tile/IndustrialProcessingTile.java
+++ b/src/main/java/com/buuz135/industrial/block/tile/IndustrialProcessingTile.java
@@ -27,6 +27,7 @@ import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.api.IFactory;
 import com.hrznstudio.titanium.api.augment.AugmentTypes;
 import com.hrznstudio.titanium.api.client.IScreenAddon;
+import com.hrznstudio.titanium.block.redstone.RedstoneAction;
 import com.hrznstudio.titanium.client.screen.addon.ProgressBarScreenAddon;
 import com.hrznstudio.titanium.component.progress.ProgressBarComponent;
 import com.hrznstudio.titanium.item.AugmentWrapper;
@@ -80,7 +81,7 @@ public abstract class IndustrialProcessingTile<T extends IndustrialProcessingTil
                             int maxProgress = (int) Math.floor(getMaxProgress() * (this.hasAugmentInstalled(AugmentTypes.EFFICIENCY) ? AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.EFFICIENCY).get(0), AugmentTypes.EFFICIENCY) : 1));
                             progressBar.setMaxProgress(maxProgress);
                         }).
-                        setCanIncrease(tileEntity -> getEnergyStorage().getEnergyStored() >= getTickPower() && canIncrease() && this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()).
+                        setCanIncrease(tileEntity -> getEnergyStorage().getEnergyStored() >= getTickPower() && canIncrease() && (this.getRedstoneManager().getAction() == RedstoneAction.IGNORE || (this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()))).
                         setOnTickWork(() -> {
                             getEnergyStorage().extractEnergy(getTickPower(), false);
                             progressBar.setProgressIncrease(this.hasAugmentInstalled(AugmentTypes.SPEED) ? (int) AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.SPEED).get(0), AugmentTypes.SPEED) : 1);

--- a/src/main/java/com/buuz135/industrial/block/tile/IndustrialWorkingTile.java
+++ b/src/main/java/com/buuz135/industrial/block/tile/IndustrialWorkingTile.java
@@ -28,6 +28,7 @@ import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.api.IFactory;
 import com.hrznstudio.titanium.api.augment.AugmentTypes;
 import com.hrznstudio.titanium.api.client.IScreenAddon;
+import com.hrznstudio.titanium.block.redstone.RedstoneAction;
 import com.hrznstudio.titanium.client.screen.addon.ProgressBarScreenAddon;
 import com.hrznstudio.titanium.client.screen.asset.IAssetProvider;
 import com.hrznstudio.titanium.component.progress.ProgressBarComponent;
@@ -99,7 +100,7 @@ public abstract class IndustrialWorkingTile<T extends IndustrialWorkingTile<T>> 
                     workingBar.setProgressIncrease(this.hasAugmentInstalled(AugmentTypes.SPEED) ? (int) AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.SPEED).get(0), AugmentTypes.SPEED) : 1);
                 })
                 .setCanReset(tileEntity -> true)
-                .setCanIncrease(tileEntity -> this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork())
+                .setCanIncrease(tileEntity -> this.getRedstoneManager().getAction() == RedstoneAction.IGNORE || (this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()))
                 .setColor(DyeColor.LIME));
     }
 


### PR DESCRIPTION
a bit ugly, wanted to extract it into its own method but IndustrialWorkingTile uses the `tileEntity` parameter's `getEnvironmentValue` instead of `this`. Not sure if that's intended.