### PR TITLE
perf: specialized early exits for known redstone actions

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/misc/tile/InfinityChargerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/misc/tile/InfinityChargerTile.java
@@ -49,7 +49,7 @@ public class InfinityChargerTile extends IndustrialMachineTile<InfinityChargerTi
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state, InfinityChargerTile blockEntity) {
-        if (!chargingSlot.getStackInSlot(0).isEmpty() && this.getRedstoneManager().getAction().canRun(this.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()) {
+        if (!chargingSlot.getStackInSlot(0).isEmpty() && this.shouldWork()) {
             var iEnergyStorage = chargingSlot.getStackInSlot(0).getCapability(Capabilities.EnergyStorage.ITEM);
             if (iEnergyStorage != null && this.getEnergyStorage() instanceof InfinityEnergyStorage) {
                 if (iEnergyStorage instanceof InfinityEnergyStorage) {

--- a/src/main/java/com/buuz135/industrial/block/tile/IndustrialMachineTile.java
+++ b/src/main/java/com/buuz135/industrial/block/tile/IndustrialMachineTile.java
@@ -143,6 +143,20 @@ public abstract class IndustrialMachineTile<T extends IndustrialMachineTile<T>> 
         redstoneManager.setLastRedstoneState(this.getEnvironmentValue(false, null).isReceivingRedstone());
     }
 
+    public boolean shouldWork() {
+        var redstone = this.getRedstoneManager();
+        var action = redstone.getAction();
+
+        // Specialized impls for known actions to avoid having to call getEnvironmentValue every tick
+        return switch (action) {
+            case IGNORE -> true;
+            case ONCE -> redstone.shouldWork();
+            case WITH_REDSTONE -> redstone.getLastRedstoneState();
+            case NO_REDSTONE -> !redstone.getLastRedstoneState();
+            default -> redstone.shouldWork() && action.canRun(this.getEnvironmentValue(false, null));
+        };
+    }
+
     @Override
     public IAssetProvider getAssetProvider() {
         return IndustrialAssetProvider.INSTANCE;

--- a/src/main/java/com/buuz135/industrial/block/tile/IndustrialProcessingTile.java
+++ b/src/main/java/com/buuz135/industrial/block/tile/IndustrialProcessingTile.java
@@ -80,7 +80,7 @@ public abstract class IndustrialProcessingTile<T extends IndustrialProcessingTil
                             int maxProgress = (int) Math.floor(getMaxProgress() * (this.hasAugmentInstalled(AugmentTypes.EFFICIENCY) ? AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.EFFICIENCY).get(0), AugmentTypes.EFFICIENCY) : 1));
                             progressBar.setMaxProgress(maxProgress);
                         }).
-                        setCanIncrease(tileEntity -> getEnergyStorage().getEnergyStored() >= getTickPower() && canIncrease() && this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork()).
+                        setCanIncrease(tileEntity -> this.shouldWork() && getEnergyStorage().getEnergyStored() >= getTickPower() && canIncrease()).
                         setOnTickWork(() -> {
                             getEnergyStorage().extractEnergy(getTickPower(), false);
                             progressBar.setProgressIncrease(this.hasAugmentInstalled(AugmentTypes.SPEED) ? (int) AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.SPEED).get(0), AugmentTypes.SPEED) : 1);

--- a/src/main/java/com/buuz135/industrial/block/tile/IndustrialWorkingTile.java
+++ b/src/main/java/com/buuz135/industrial/block/tile/IndustrialWorkingTile.java
@@ -99,7 +99,7 @@ public abstract class IndustrialWorkingTile<T extends IndustrialWorkingTile<T>> 
                     workingBar.setProgressIncrease(this.hasAugmentInstalled(AugmentTypes.SPEED) ? (int) AugmentWrapper.getType(this.getInstalledAugments(AugmentTypes.SPEED).get(0), AugmentTypes.SPEED) : 1);
                 })
                 .setCanReset(tileEntity -> true)
-                .setCanIncrease(tileEntity -> this.getRedstoneManager().getAction().canRun(tileEntity.getEnvironmentValue(false, null)) && this.getRedstoneManager().shouldWork())
+                .setCanIncrease(IndustrialMachineTile::shouldWork)
                 .setColor(DyeColor.LIME));
     }
 


### PR DESCRIPTION
cleaner and more effective redo of #1644 
eliminates the need to check for nearby signals every tick for all current RedstoneAction values, defaulting to the old implementation for any future ones.