### PR TITLE
refactor: harvesting things

### DIFF
--- a/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
@@ -94,6 +94,7 @@ public class BlockUtils {
         var block = state.getBlock();
         return block.equals(Blocks.SHROOMLIGHT)
                 || block.equals(Blocks.MOSS_CARPET)
+                || block.equals(Blocks.WEEPING_VINES)
                 || (block.equals(Blocks.MANGROVE_PROPAGULE) && state.getValue(MangrovePropaguleBlock.HANGING))
                 || state.is(BlockTags.LEAVES)
                 || state.is(BlockTags.WART_BLOCKS);

--- a/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
@@ -61,6 +61,9 @@ public class BlockUtils {
         return blocks;
     }
 
+    /**
+     * Use {@link BlockUtils#isBlockStateTag(BlockState, TagKey)} if you need the {@code BlockState} anyways
+     */
     public static boolean isBlockTag(Level world, BlockPos pos, TagKey<Block> tag) {
         return isBlockStateTag(world.getBlockState(pos), tag);
     }
@@ -69,20 +72,42 @@ public class BlockUtils {
         return state.is(tag);
     }
 
+    /**
+     * Use {@link BlockUtils#isBlockStateLog(BlockState)} if you need the {@code BlockState} anyways
+     */
     public static boolean isLog(Level world, BlockPos pos) {
-        return isBlockTag(world, pos, BlockTags.LOGS) || world.getBlockState(pos).is(Blocks.MANGROVE_ROOTS);
+        return isBlockStateLog(world.getBlockState(pos));
     }
 
+    public static boolean isBlockStateLog(BlockState state) {
+        return state.is(BlockTags.LOGS) || state.is(Blocks.MANGROVE_ROOTS);
+    }
+
+    /**
+     * Use {@link BlockUtils#isBlockStateLeaves(BlockState)} if you need the {@code BlockState} anyways
+     */
     public static boolean isLeaves(Level world, BlockPos pos) {
-        return world.getBlockState(pos).is(BlockTags.WART_BLOCKS)
-                || world.getBlockState(pos).is(BlockTags.LEAVES)
-                || world.getBlockState(pos).getBlock().equals(Blocks.SHROOMLIGHT)
-                || world.getBlockState(pos).getBlock().equals(Blocks.MOSS_CARPET)
-                || (world.getBlockState(pos).getBlock().equals(Blocks.MANGROVE_PROPAGULE) && world.getBlockState(pos).getValue(MangrovePropaguleBlock.HANGING));
+        return isBlockStateLeaves(world.getBlockState(pos));
     }
 
+    public static boolean isBlockStateLeaves(BlockState state) {
+        var block = state.getBlock();
+        return block.equals(Blocks.SHROOMLIGHT)
+                || block.equals(Blocks.MOSS_CARPET)
+                || (block.equals(Blocks.MANGROVE_PROPAGULE) && state.getValue(MangrovePropaguleBlock.HANGING))
+                || state.is(BlockTags.LEAVES)
+                || state.is(BlockTags.WART_BLOCKS);
+    }
+
+    /**
+     * Use {@link BlockUtils#isBlockChorus(Block)} if you need the {@code BlockState} or {@code Block} anyways
+     */
     public static boolean isChorus(Level world, BlockPos pos) {
-        return world.getBlockState(pos).getBlock().equals(Blocks.CHORUS_PLANT) || world.getBlockState(pos).getBlock().equals(Blocks.CHORUS_FLOWER);
+        return isBlockChorus(world.getBlockState(pos).getBlock());
+    }
+
+    public static boolean isBlockChorus(Block block) {
+        return block.equals(Blocks.CHORUS_PLANT) || block.equals(Blocks.CHORUS_FLOWER);
     }
 
     public static boolean canBlockBeBroken(Level world, BlockPos pos, String uuid) {

--- a/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/ChorusCache.java
+++ b/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/ChorusCache.java
@@ -24,7 +24,6 @@ package com.buuz135.industrial.utils.apihandlers.plant;
 
 import com.buuz135.industrial.utils.BlockUtils;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -49,9 +48,16 @@ public class ChorusCache {
         while (!chorus.isEmpty()) {
             BlockPos checking = chorus.pop();
             if (BlockUtils.isChorus(world, checking)) {
-                Iterable<BlockPos> area = BlockPos.betweenClosed(checking.relative(Direction.DOWN).relative(Direction.SOUTH).relative(Direction.WEST), checking.relative(Direction.UP).relative(Direction.NORTH).relative(Direction.EAST));
+                Iterable<BlockPos> area = BlockPos.betweenClosed(checking.offset(-1, 0, -1), checking.offset(1, 1, 1));
                 for (BlockPos blockPos : area) {
-                    if (BlockUtils.isChorus(world, blockPos) && !this.chorus.contains(blockPos) && blockPos.distSqr(current) <= 100) {
+                    // Chorus can grow up to 22 blocks, tall - assuming it grows sideways each time as well, you have a
+                    // max distance of sqrt(22^2 + 22^2) = 31.11...
+                    // We round that up to 32 then square it to get 1024.
+                    if (blockPos.distSqr(current) > 1024) {
+                        continue;
+                    }
+                    
+                    if (BlockUtils.isChorus(world, blockPos) && !this.chorus.contains(blockPos)) {
                         chorus.push(blockPos.immutable());
                         this.chorus.add(blockPos.immutable());
                     }
@@ -75,6 +81,10 @@ public class ChorusCache {
     public List<ItemStack> chop() {
         NonNullList<ItemStack> stacks = NonNullList.create();
         int maxY = getTopRowY();
+        if (maxY == Integer.MIN_VALUE) {
+            return stacks;
+        }
+
         var iter = chorus.listIterator();
         while (iter.hasNext()) {
             var blockPos = iter.next();
@@ -100,7 +110,7 @@ public class ChorusCache {
     }
 
     public int getTopRowY() {
-        int i = 0;
+        int i = Integer.MIN_VALUE;
         for (BlockPos blockPos : chorus) {
             if (blockPos.getY() > i) i = blockPos.getY();
         }

--- a/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/ChorusCache.java
+++ b/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/ChorusCache.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChorusFlowerBlock;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,20 +61,36 @@ public class ChorusCache {
     }
 
     public boolean isFullyGrown() {
-        return chorus.stream().map(blockpos -> world.getBlockState(blockpos)).allMatch(blockState -> blockState.getBlock().equals(Blocks.CHORUS_PLANT) || (blockState.getBlock().equals(Blocks.CHORUS_FLOWER) && blockState.getValue(ChorusFlowerBlock.AGE) == 5));
+        for (BlockPos blockpos : chorus) {
+            BlockState blockState = world.getBlockState(blockpos);
+            var block = blockState.getBlock();
+            if (!block.equals(Blocks.CHORUS_PLANT) && (!block.equals(Blocks.CHORUS_FLOWER) || blockState.getValue(ChorusFlowerBlock.AGE) != 5)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public List<ItemStack> chop() {
         NonNullList<ItemStack> stacks = NonNullList.create();
         int maxY = getTopRowY();
-        chorus.stream().filter(pos -> pos.getY() == maxY).forEach(pos -> chop(stacks, pos));
-        chorus.removeIf(pos -> pos.getY() == maxY);
+        var iter = chorus.listIterator();
+        while (iter.hasNext()) {
+            var blockPos = iter.next();
+            if (blockPos.getY() == maxY) {
+                chop(stacks, blockPos);
+                iter.remove();
+            }
+        }
         return stacks;
     }
 
     public void chop(NonNullList<ItemStack> stacks, BlockPos p) {
-        if (BlockUtils.isChorus(world, p)) {
-            if (world.getBlockState(p).getBlock().equals(Blocks.CHORUS_FLOWER)) {
+        var state = world.getBlockState(p);
+        var block = state.getBlock();
+        if (BlockUtils.isBlockChorus(block)) {
+            if (block.equals(Blocks.CHORUS_FLOWER)) {
                 stacks.add(new ItemStack(Blocks.CHORUS_FLOWER));
             } else {
                 stacks.addAll(BlockUtils.getBlockDrops(world, p));

--- a/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/TreeCache.java
+++ b/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/TreeCache.java
@@ -24,6 +24,7 @@ package com.buuz135.industrial.utils.apihandlers.plant;
 
 import com.buuz135.industrial.utils.BlockUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.item.ItemStack;
@@ -52,8 +53,8 @@ public class TreeCache {
     public List<ItemStack> chop(Queue<BlockPos> cache, boolean shear) {
         BlockPos p = cache.peek();
         NonNullList<ItemStack> stacks = NonNullList.create();
-        if (BlockUtils.isLeaves(world, p) || BlockUtils.isLog(world, p)) {
-            BlockState s = world.getBlockState(p);
+        BlockState s = world.getBlockState(p);
+        if (BlockUtils.isBlockStateLeaves(s) || BlockUtils.isBlockStateLog(s)) {
             if (s.getBlock() instanceof IShearable shearable && shear) {
                 stacks.addAll(shearable.onSheared(null, new ItemStack(Items.SHEARS), world, p));
             } else {
@@ -88,16 +89,18 @@ public class TreeCache {
         }
         while (!tree.isEmpty()) {
             BlockPos checking = tree.pop();
-            if (BlockUtils.isLeaves(world, checking) || BlockUtils.isLog(world, checking)) {
+            var checkingState = world.getBlockState(checking);
+            if (BlockUtils.isBlockStateLeaves(checkingState) || BlockUtils.isBlockStateLog(checkingState)) {
                 for (BlockPos pos : BlockPos.betweenClosed(checking.offset(-1, -1, -1), checking.offset(1, 1, 1))) {
                     BlockPos blockPos = pos.immutable();
-                    if (world.isEmptyBlock(blockPos) || checkedPositions.contains(blockPos) || blockPos.distManhattan(new Vec3i(current.getX(), current.getY(), current.getZ())) > 100 /*BlockRegistry.cropRecolectorBlock.getMaxDistanceTreeBlocksScan()*/)
+                    var state = world.getBlockState(blockPos);
+                    if (state.isAir() || checkedPositions.contains(blockPos) || blockPos.distManhattan(new Vec3i(current.getX(), current.getY(), current.getZ())) > 100 /*BlockRegistry.cropRecolectorBlock.getMaxDistanceTreeBlocksScan()*/)
                         continue;
-                    if (BlockUtils.isLeaves(world, blockPos)) {
+                    if (BlockUtils.isBlockStateLeaves(state)) {
                         tree.push(blockPos);
                         leavesCache.add(blockPos);
                         checkedPositions.add(blockPos);
-                    } else if (BlockUtils.isLog(world, blockPos)) {
+                    } else if (BlockUtils.isBlockStateLog(state)) {
                         tree.push(blockPos);
                         woodCache.add(blockPos);
                         checkedPositions.add(blockPos);
@@ -108,8 +111,14 @@ public class TreeCache {
     }
 
     public BlockPos getHighestBlock(BlockPos position) {
-        while (!this.world.isEmptyBlock(position.above()) && (BlockUtils.isLog(this.world, position.above()) || BlockUtils.isLeaves(this.world, position.above())))
-            position = position.above();
-        return position;
+        var chunk = this.world.getChunkAt(position);
+        var mutable = position.mutable();
+        BlockState state;
+        do {
+            mutable.move(Direction.UP);
+            state = chunk.getBlockState(mutable);
+        } while (!state.isAir() && (BlockUtils.isBlockStateLeaves(state) || BlockUtils.isBlockStateLog(state)));
+
+        return mutable.below();
     }
 }

--- a/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/TreeCache.java
+++ b/src/main/java/com/buuz135/industrial/utils/apihandlers/plant/TreeCache.java
@@ -89,7 +89,7 @@ public class TreeCache {
         while (!tree.isEmpty()) {
             BlockPos checking = tree.pop();
             if (BlockUtils.isLeaves(world, checking) || BlockUtils.isLog(world, checking)) {
-                for (BlockPos pos : BlockPos.betweenClosed(checking.offset(-1, 0, -1), checking.offset(1, 1, 1))) {
+                for (BlockPos pos : BlockPos.betweenClosed(checking.offset(-1, -1, -1), checking.offset(1, 1, 1))) {
                     BlockPos blockPos = pos.immutable();
                     if (world.isEmptyBlock(blockPos) || checkedPositions.contains(blockPos) || blockPos.distManhattan(new Vec3i(current.getX(), current.getY(), current.getZ())) > 100 /*BlockRegistry.cropRecolectorBlock.getMaxDistanceTreeBlocksScan()*/)
                         continue;


### PR DESCRIPTION
check for leaves below to accomodate cherry/nether/modded trees
introduce and use methods in `BlockUtils` that take `BlockState`/`Block` that are more efficient especially if the `BlockState`/`Block` is needed later, making existing methods redirect to them.
remove some usages of streams
