### PR TITLE
fix: Fluid Extractor crack overlay leaking across dimensions and never clearing after a block is fully processed

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/core/tile/FluidExtractorTile.java
+++ b/src/main/java/com/buuz135/industrial/block/core/tile/FluidExtractorTile.java
@@ -32,12 +32,12 @@ import com.hrznstudio.titanium.component.fluid.FluidTankComponent;
 import com.hrznstudio.titanium.component.fluid.SidedFluidTankComponent;
 import com.hrznstudio.titanium.util.RecipeUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -48,7 +48,7 @@ import java.util.HashMap;
 
 public class FluidExtractorTile extends IndustrialAreaWorkingTile<FluidExtractorTile> {
 
-    public static HashMap<DimensionType, HashMap<ChunkPos, HashMap<BlockPos, FluidExtractionProgress>>> EXTRACTION = new HashMap<>();
+    public static HashMap<ResourceKey<Level>, HashMap<ChunkPos, HashMap<BlockPos, FluidExtractionProgress>>> EXTRACTION = new HashMap<>();
 
     private int maxProgress;
     private int powerPerOperation;
@@ -73,8 +73,9 @@ public class FluidExtractorTile extends IndustrialAreaWorkingTile<FluidExtractor
         if (isLoaded(pos) && !this.level.isEmptyBlock(pos) && this.tank.getFluidAmount() < this.tank.getCapacity()) {
             if (currentRecipe == null || !currentRecipe.matches(this.level, pos) || currentRecipe.defaultRecipe)
                 currentRecipe = findRecipe(this.level, pos);
-            if (currentRecipe != null) {//GetDimensionType
-                FluidExtractionProgress extractionProgress = EXTRACTION.computeIfAbsent(this.level.dimensionType(), dimensionType -> new HashMap<>()).computeIfAbsent(this.level.getChunkAt(pos).getPos(), chunkPos -> new HashMap<>()).computeIfAbsent(pos, pos1 -> new FluidExtractionProgress(this.level));
+            if (currentRecipe != null) {//GetDimension
+                HashMap<BlockPos, FluidExtractionProgress> chunkExtractionMap = EXTRACTION.computeIfAbsent(this.level.dimension(), dimensionKey -> new HashMap<>()).computeIfAbsent(this.level.getChunkAt(pos).getPos(), chunkPos -> new HashMap<>());
+                FluidExtractionProgress extractionProgress = chunkExtractionMap.computeIfAbsent(pos, pos1 -> new FluidExtractionProgress(this.level));
                 if (currentRecipe.output.getFluid().isSame(ModuleCore.LATEX.getSourceFluid().get())) {
                     tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (hasEnergy(powerPerOperation) ? 3 : 1)), IFluidHandler.FluidAction.EXECUTE);
                 } else {
@@ -84,7 +85,8 @@ public class FluidExtractorTile extends IndustrialAreaWorkingTile<FluidExtractor
                     extractionProgress.setProgress(extractionProgress.getProgress() + 1);
                 }
                 if (extractionProgress.getProgress() > 7) {
-                    extractionProgress.setProgress(0);
+                    this.level.destroyBlockProgress(extractionProgress.getBreakID(), pos, -1);
+                    chunkExtractionMap.remove(pos);
                     this.level.setBlockAndUpdate(pos, currentRecipe.result.defaultBlockState());
                     if (currentRecipe.output.getFluid().isSame(ModuleCore.LATEX.getSourceFluid().get())) {
                         tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (hasEnergy(powerPerOperation) ? 200 : 1)), IFluidHandler.FluidAction.EXECUTE);

--- a/src/main/java/com/buuz135/industrial/module/ModuleCore.java
+++ b/src/main/java/com/buuz135/industrial/module/ModuleCore.java
@@ -55,6 +55,9 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraft.network.protocol.game.ClientboundBlockDestructionPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -134,8 +137,21 @@ public class ModuleCore implements IModule {
         SUPREME = helper.registerBlockWithItem("machine_frame_supreme", () -> new MachineFrameBlock(SUPREME_RARITY, TAB_CORE), (block) -> () -> new MachineFrameBlock.MachineFrameItem(block.get(), SUPREME_RARITY, TAB_CORE), TAB_CORE);
         //DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::onClient);
         EventManager.forge(TickEvent.LevelTickEvent.class).
-                filter(worldTickEvent -> worldTickEvent.phase == TickEvent.Phase.END && worldTickEvent.type == TickEvent.Type.LEVEL && worldTickEvent.level.getGameTime() % 40 == 0 && FluidExtractorTile.EXTRACTION.containsKey(worldTickEvent.level.dimensionType())).
-                process(worldTickEvent -> FluidExtractorTile.EXTRACTION.get(worldTickEvent.level.dimensionType()).values().forEach(blockPosFluidExtractionProgressHashMap -> blockPosFluidExtractionProgressHashMap.keySet().forEach(pos -> worldTickEvent.level.destroyBlockProgress(blockPosFluidExtractionProgressHashMap.get(pos).getBreakID(), pos, blockPosFluidExtractionProgressHashMap.get(pos).getProgress())))).subscribe();
+                filter(worldTickEvent -> worldTickEvent.phase == TickEvent.Phase.END && worldTickEvent.type == TickEvent.Type.LEVEL && worldTickEvent.level.getGameTime() % 40 == 0 && FluidExtractorTile.EXTRACTION.containsKey(worldTickEvent.level.dimension())).
+                process(worldTickEvent -> FluidExtractorTile.EXTRACTION.get(worldTickEvent.level.dimension()).values().forEach(blockPosFluidExtractionProgressHashMap -> blockPosFluidExtractionProgressHashMap.keySet().forEach(pos -> worldTickEvent.level.destroyBlockProgress(blockPosFluidExtractionProgressHashMap.get(pos).getBreakID(), pos, blockPosFluidExtractionProgressHashMap.get(pos).getProgress())))).subscribe();
+        EventManager.forge(PlayerEvent.PlayerChangedDimensionEvent.class).
+                filter(changedDimensionEvent -> changedDimensionEvent.getEntity() instanceof ServerPlayer).
+                process(changedDimensionEvent -> {
+                    ServerPlayer player = (ServerPlayer) changedDimensionEvent.getEntity();
+                    if (FluidExtractorTile.EXTRACTION.containsKey(changedDimensionEvent.getFrom())) {
+                        FluidExtractorTile.EXTRACTION.get(changedDimensionEvent.getFrom()).values().forEach(blockPosFluidExtractionProgressHashMap -> blockPosFluidExtractionProgressHashMap.forEach((pos, progress) ->
+                                player.connection.send(new ClientboundBlockDestructionPacket(progress.getBreakID(), pos, -1))));
+                    }
+                    if (FluidExtractorTile.EXTRACTION.containsKey(changedDimensionEvent.getTo())) {
+                        FluidExtractorTile.EXTRACTION.get(changedDimensionEvent.getTo()).values().forEach(blockPosFluidExtractionProgressHashMap -> blockPosFluidExtractionProgressHashMap.forEach((pos, progress) ->
+                                player.connection.send(new ClientboundBlockDestructionPacket(progress.getBreakID(), pos, progress.getProgress()))));
+                    }
+                }).subscribe();
         for (int i = 0; i < RANGE_ADDONS.length; i++) {
             int finalI = i;
             RANGE_ADDONS[i] = helper.registerGeneric(ForgeRegistries.ITEMS.getRegistryKey(), "range_addon" + i, () -> new RangeAddonItem(finalI, TAB_CORE));


### PR DESCRIPTION
The current implementation of Fluid Extractor caused cross dimension crack leak between dimension with the same type (eg: Hyperbox), it also never clear the EXTRACTION hashmap entries causing a small insignificant memory leak (still) and crack persist after block finished process until client disconnect (multiplayer) or restart (singleplayer)

This PR aim to fix these issues by:
1. using dimension `ResourceKey<Level>` as key instead of `DimensionType` to target specific dimension
2. remove hashmap entry when progress is 0
3. hook `PlayerChangedDimensionEvent`, so that when switching between dimension, client will clear the crack rendering immidiately and also render the crack within same dimension immidiately