### PR TITLE
Fix typo in tooltip for fluid acceptance

### DIFF
--- a/src/main/resources/assets/industrialforegoing/lang/en_us.json
+++ b/src/main/resources/assets/industrialforegoing/lang/en_us.json
@@ -103,7 +103,7 @@
   "text.industrialforegoing.tooltip.efficiency": "Processing Time Reduction: ",
   "text.industrialforegoing.tooltip.processing": "Processing: ",
   "text.industrialforegoing.tooltip.speed": "Speed Increase: ",
-  "text.industrialforegoing.tooltip.accepts_fluid_on_top": "Will use fluids from tanks placed on top of the mahcine",
+  "text.industrialforegoing.tooltip.accepts_fluid_on_top": "Will use fluids from tanks placed on top of the machine",
   "tooltip.industrialforegoing.type": "Type: ",
   "text.industrialforegoing.up": "Up",
   "text.industrialforegoing.down": "Down",


### PR DESCRIPTION
This pull request includes a minor correction to a tooltip string in the `en_us.json` localization file, fixing a typo in the word "machine".

* Fixed typo in the tooltip text for accepting fluids from tanks placed on top of the machine (`src/main/resources/assets/industrialforegoing/lang/en_us.json`).